### PR TITLE
Add spaces to headings in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-#Contributing to PWA Builder
+# Contributing to PWA Builder
 
-##Join in the Fun
+## Join in the Fun
 
 PWA Builder is a community project. Our goal is to leverage community tools when possible, build for the platforms the Web Developer community will target, and solicit contributes from the community at large.  We would love to have some help from our developers. You can contribute in a number of ways:
 
@@ -9,7 +9,7 @@ PWA Builder is a community project. Our goal is to leverage community tools when
 3. **Support a new platform**: Are there other platforms that your targeting that support (or have a polyfill for) hosted web apps?  Contribute the code to support additional platforms (see contribute guidelines below).
 
 
-##Contribution Guidelines
+## Contribution Guidelines
 
 1. Code contribution must have an issue tracking it in the issue tracker that has been approved (Status = Active) by the PWA Builder team. Your pull request should include a link to the bug that you are fixing
 2. You will need to complete a Contributor License Agreement (CLA). Briefly, this agreement testifies that you are granting us permission to use the submitted change according to the terms of the project’s license, and that the work being submitted is under appropriate copyright. (docx:  [Microsoft Contribution License Agreement.docx](https://www.codeplex.com/Download?ProjectName=typescript&DownloadId=822190), pdf:  [Microsoft Contribution License Agreement.pdf](https://www.codeplex.com/Download?ProjectName=typescript&DownloadId=921298) ).

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ pwabuilder <command> [options]
 | `-f, --forceManifestFormat`  | **(optional)** Allows to specify the manifest format and skip the automatic detection. Can be used when the manifest contains additional, non-standard members. |
 | `-c, --crosswalk` | **(optional)** Enable Crosswalk for Android. Crosswalk is a web runtime that can be used to replace the stock WebView used by Android Cordova apps. Crosswalk is based on Google Chromium with Cordova API support and has better HTML5 feature support compared to the default WebView available in Android. |
 | `-w, --webAppToolkit` | **(optional)** Adds the [Web App Toolkit](https://github.com/manifoldjs/Web-App-ToolKit) cordova plugin. The Web App Toolkit is a plugin for creating Windows, Android and iOS apps based on existing web content. It depends on the Hosted Web App Plugin. Used in the right way, it can facilitate the creation of compelling extensions to your web content for users across platforms. |
-| `-S, --Sign` | **(optional - for _package_ command)** Return a signed package for Windows 10. |
-| `-W, --DotWeb` | **(optional - for _package_ command)** Generate a .web package for Windows 10. |
-| `-a, --AutoPublish` | **(optional - for _package_ command)** Auto-publish a package for Windows 10. |
+| `-S, --Sign` | **(deprecated --optional - for _package_ command)** Return a signed package for Windows 10. |
+| `-W, --DotWeb` | **(deprecated --optional - for _package_ command)** Generate a .web package for Windows 10. |
+| `-a, --AutoPublish` | **(deprecated --optional - for _package_ command)** Auto-publish a package for Windows 10. |
 
 ### Commands
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwabuilder",
-  "version": "2.0.2-rc.1",
+  "version": "2.0.3-rc.0",
   "description": "Node.js Tool for App Generation",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "q": "^1.4.1",
     "pwabuilder-lib": "^2.0.0-rc",
     "pwabuilder-web": "^2.0.0-rc",
-    "pwabuilder-windows10": "^2.0.1-rc",
+    "pwabuilder-windows10": "^2.0.3-rc",
     "pwabuilder-cordova": "^2.0.0-rc",
     "pwabuilder-edgeextension": "^2.0.0-rc"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwabuilder",
-  "version": "2.0.1-rc.1",
+  "version": "2.0.2-rc.1",
   "description": "Node.js Tool for App Generation",
   "repository": {
     "type": "git",


### PR DESCRIPTION
So that Github formats the headings correctly when it renders the markdown as HTML.