### PR TITLE
Fix typo in README.md code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ pwabuilder package -p windows10 -l debug
 ### Manifest Module
 
 ````
-var manifesTools = require('manifestTools');
+var manifestTools = require('manifestTools');
 ````
 
 #### getManifestFromSite(siteUrl, callback)


### PR DESCRIPTION
I think manifesTools was a typo and not a stylistic choice 😅