### PR TITLE
Update/Add MacOS & Android native platforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "pwabuilder-web": "^2.0.0-rc",
     "pwabuilder-windows10": "^2.0.1-rc",
     "pwabuilder-cordova": "^2.0.0-rc",
+    "pwabuilder-android": "^2.0.0-rc",
     "pwabuilder-edgeextension": "^2.0.0-rc"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "pwabuilder-windows10": "^2.0.1-rc",
     "pwabuilder-cordova": "^2.0.0-rc",
     "pwabuilder-android": "^2.0.0-rc",
+    "pwabuilder-macos": "^0.3.0",
     "pwabuilder-edgeextension": "^2.0.0-rc"
   },
   "devDependencies": {

--- a/platforms.json
+++ b/platforms.json
@@ -4,8 +4,12 @@
         "source": "pwabuilder-windows10"
     },
     "android": {
-        "packageName": "pwabuilder-cordova",
-        "source": "pwabuilder-cordova"
+        "packageName": "pwabuilder-android",
+        "source": "pwabuilder-android"
+    },
+    "mac": {
+        "packageName": "pwabuilder-mac",
+        "source": "pwabuilder-mac"
     },
     "ios": {
         "packageName": "pwabuilder-cordova",

--- a/platforms.json
+++ b/platforms.json
@@ -9,7 +9,7 @@
     },
     "macos": {
         "packageName": "pwabuilder-macos",
-        "source": "pwabuilder-mac"
+        "source": "pwabuilder-macos"
     },
     "ios": {
         "packageName": "pwabuilder-cordova",

--- a/platforms.json
+++ b/platforms.json
@@ -7,8 +7,8 @@
         "packageName": "pwabuilder-android",
         "source": "pwabuilder-android"
     },
-    "mac": {
-        "packageName": "pwabuilder-mac",
+    "macos": {
+        "packageName": "pwabuilder-macos",
         "source": "pwabuilder-mac"
     },
     "ios": {


### PR DESCRIPTION
In this PR we:

- Update the Android platform version with their native one.
- Add MacOs native platform to manifold-api
- Add pwabuilder-android module in package.json